### PR TITLE
UMCS-4 Rename MGW to PAPI

### DIFF
--- a/src/main/java/com/unzer/payment/Linkpay.java
+++ b/src/main/java/com/unzer/payment/Linkpay.java
@@ -503,7 +503,7 @@ public class Linkpay implements PaymentType {
 
 	@Override
 	public String toString() {
-		return "\nnet.hpcsoft.mgw.papi.api.linkpay.model.LinkPayResponse{" +
+		return "\nnet.hpcsoft.papi.api.linkpay.model.LinkPayResponse{" +
 				"\n\tid='" + id + '\'' +
 				", \n\tredirectUrl='" + redirectUrl + '\'' +
 				", \n\tversion='" + version + '\'' +


### PR DESCRIPTION
* Changed "mgw" to "papi" in ToString()-Method of Linkpay-Class