### PR TITLE
Java SDK - Log4j Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 *   Upgrade of the used Log4j Dependencies to fix the Log4j Zero-Day-Exploit
+*   Bumped log4j-Dependency from 2.15.0 to 2.16.0
+*   Bumped Maven-Dependency-Check-Dependency from 5.3.2 to 6.5.0
+*   Bumped httpclient from 4.5.12 to 4.5.13
+*   Bumped junit from 4.13 to 4.13.1
+*   Bumped jsoup from 1.13.1 to 1.14.2
 *   Several minor improvements.
 
 ## [1.1.2.1][1.1.2.1]

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.3.2</version>
+                <version>6.5.0</version>
                 <configuration>
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipRuntimeScope>true</skipRuntimeScope>
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
 
         <dependency>
@@ -269,21 +269,21 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.12</version>
+            <version>4.5.13</version>
         </dependency>
 
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.13.1</version>
+            <version>1.14.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
- Bumped log4j-Dependency from 2.15.0 to 2.16.0
- Bumped Maven-Dependency-Check-Dependency from 5.3.2 to 6.5.0
- Bumped httpclient from 4.5.12 to 4.5.13
- Bumped junit from 4.13 to 4.13.1
- Bumped jsoup from 1.13.1 to 1.14.2