### PR TITLE
Java SDK - Log4j Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 *   Bumped httpclient from 4.5.12 to 4.5.13
 *   Bumped junit from 4.13 to 4.13.1
 *   Bumped jsoup from 1.13.1 to 1.14.2
-*   Increased Deployment Timeout for Sonatype to 15 Minutes 
+*   Increased Deployment Timeout for Sonatype to 20 Minutes 
 *   Several minor improvements.
 
 ## [1.1.2.2][1.1.2.2]

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
                     <serverId>mpay24</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+                    <stagingProgressTimeoutMinutes>20</stagingProgressTimeoutMinutes>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
- Increased Sonatype Deployment Timeout to 20 Minutes