### PR TITLE
UMCS-326: Added a Json-Validation before real Json-Deserialization ha…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.1.2.6][1.1.2.6]
 
-### Changed
-
+### Added
 *   Added Unzer-Logo and updated the reference in Readme-File.
 *   Added Json-Validation to JsonParser-Class before real Json-Deserialization happens.
 *   Added Twitter-Handle to Readme-File.
+
+### Changed
 *   Several minor improvements.
 
 ## [1.1.2.5][1.1.2.5]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres
 to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.2.6][1.1.2.6]
+
+### Changed
+
+*   Added Unzer-Logo and updated the reference in Readme-File.
+*   Added Json-Validation to JsonParser-Class before real Json-Deserialization happens.
+*   Added Twitter-Handle to Readme-File.
+*   Several minor improvements.
+
 ## [1.1.2.5][1.1.2.5]
 
 ### Changed
@@ -121,6 +130,8 @@ to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
     *   cancelAuthorization
 *   Remove deprecated classes
     *   RestCommunication
+
+[1.1.2.6]: http://github.com/unzerdev/java-sdk/compare/1.1.2.5..1.1.2.6
 
 [1.1.2.5]: http://github.com/unzerdev/java-sdk/compare/1.1.2.4..1.1.2.5
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Java 1.8 or later.
 <dependency>
   <groupId>com.unzer.payment</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>1.1.2.5</version>
+  <version>1.1.2.6</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.unzer.payment</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>1.1.2.5</version>
+    <version>1.1.2.6</version>
     <name>Unzer Java SDK</name>
     <description>Unzer Java SDK</description>
     <url>https://docs.unzer.com/</url>

--- a/src/main/java/com/unzer/payment/communication/JsonParser.java
+++ b/src/main/java/com/unzer/payment/communication/JsonParser.java
@@ -115,7 +115,7 @@ public class JsonParser {
 			final ObjectMapper mapper = new ObjectMapper();
 			mapper.readTree(jsonInString);
 			return true;
-		} catch (IOException e) {
+		} catch (IOException | IllegalArgumentException e) {
 			return false;
 		}
 	}

--- a/src/main/java/com/unzer/payment/communication/JsonParser.java
+++ b/src/main/java/com/unzer/payment/communication/JsonParser.java
@@ -20,9 +20,9 @@ package com.unzer.payment.communication;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,11 +31,13 @@ package com.unzer.payment.communication;
  * #L%
  */
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.unzer.payment.PaymentException;
 import com.unzer.payment.communication.json.JsonErrorObject;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.util.Currency;
@@ -64,7 +66,7 @@ public class JsonParser {
 
 	/**
 	 * Provides a function which simple parse object to json
-	 * 
+	 *
 	 * @param model refers to object to be parsed
 	 * @return json method
 	 * @throws IllegalArgumentException if the model is null
@@ -85,9 +87,12 @@ public class JsonParser {
 	 * @return an object of type T
 	 */
 	@SuppressWarnings("hiding")
-	public <T> T fromJson(String json, Class<T> clazz) {
+	public <T> T fromJson(String json, Class<T> clazz) throws IllegalArgumentException, PaymentException {
 		if (Objects.isNull(json) || Objects.isNull(clazz)) {
 			throw new IllegalArgumentException("Null object cannot be parsed!");
+		}
+		if(!isJsonValid(json)) {
+			throw new IllegalArgumentException(String.format("The provided JSON String is not valid! The provided Json was: %s", json));
 		}
 		if (isError(json) && !clazz.isAssignableFrom(JsonErrorObject.class)) {
 			throw toPaymentException(json);
@@ -103,6 +108,16 @@ public class JsonParser {
 
 	private boolean isError(String json) {
 		return json.contains(ERRORS) && json.contains(ERROR_CODE);
+	}
+
+	public boolean isJsonValid(String jsonInString) {
+		try {
+			final ObjectMapper mapper = new ObjectMapper();
+			mapper.readTree(jsonInString);
+			return true;
+		} catch (IOException e) {
+			return false;
+		}
 	}
 
 }

--- a/src/test/java/com/unzer/payment/business/AbstractSeleniumTest.java
+++ b/src/test/java/com/unzer/payment/business/AbstractSeleniumTest.java
@@ -243,7 +243,7 @@ public abstract class AbstractSeleniumTest extends AbstractPaymentTest {
 		paypage.setPrivacyPolicyUrl(new URL("https://www.unzer.com/en/privacy-statement/"));
 		paypage.setCss(getCssMap());
 
-		paypage.setLogoImage("https://dev.unzer.de/wp-content/uploads/2020/09/Unzer__PrimaryLogo_Raspberry_RGB-595x272.png");
+		paypage.setLogoImage("https://docs.unzer.com/payment-nutshell/payment-in-nutshell.png");
 		paypage.setFullPageImage("https://store.storeimages.cdn-apple.com/4668/as-images.apple.com/is/iphone-12-pro-family-hero");
 
 		paypage.setContactUrl(new URL("mailto:support@unzer.com"));
@@ -271,7 +271,7 @@ public abstract class AbstractSeleniumTest extends AbstractPaymentTest {
 		linkpay.setPrivacyPolicyUrl(new URL("https://www.unzer.com/en/datenschutz/"));
 		linkpay.setCss(getCssMap());
 
-		linkpay.setLogoImage("https://dev.unzer.de/wp-content/uploads/2020/09/Unzer__PrimaryLogo_Raspberry_RGB-595x272.png");
+		linkpay.setLogoImage("https://docs.unzer.com/payment-nutshell/payment-in-nutshell.png");
 		linkpay.setFullPageImage("https://store.storeimages.cdn-apple.com/4668/as-images.apple.com/is/iphone-12-pro-family-hero");
 
 		linkpay.setContactUrl(new URL("mailto:support@unzer.com"));

--- a/src/test/java/com/unzer/payment/communication/JsonParserTest.java
+++ b/src/test/java/com/unzer/payment/communication/JsonParserTest.java
@@ -21,15 +21,11 @@ package com.unzer.payment.communication;
  */
 
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.unzer.payment.*;
 import com.unzer.payment.business.AbstractPaymentTest;
 import com.unzer.payment.communication.json.JsonCharge;
 import com.unzer.payment.communication.json.JsonErrorObject;
 import org.junit.Test;
-
-import java.net.MalformedURLException;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/unzer/payment/communication/JsonParserTest.java
+++ b/src/test/java/com/unzer/payment/communication/JsonParserTest.java
@@ -9,9 +9,9 @@ package com.unzer.payment.communication;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,53 +21,70 @@ package com.unzer.payment.communication;
  */
 
 
-import com.unzer.payment.PaymentError;
-import com.unzer.payment.PaymentException;
-import com.unzer.payment.TestData;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.unzer.payment.*;
+import com.unzer.payment.business.AbstractPaymentTest;
 import com.unzer.payment.communication.json.JsonCharge;
 import com.unzer.payment.communication.json.JsonErrorObject;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import java.net.MalformedURLException;
 
-public class JsonParserTest {
+import static org.junit.Assert.*;
 
-	@Test
-	public void given_an_error_message_then_payment_exception_is_thrown() {
-		try {
-			JsonParser parser = new JsonParser();
-			parser.fromJson(TestData.errorJson(), JsonCharge.class);
+public class JsonParserTest extends AbstractPaymentTest {
 
-			fail("Expected PaymentException");
-		} catch (PaymentException exception) {
-			assertBasicErrorAttributes(exception.getId(), exception.getUrl(), exception.getTimestamp());
-			assertPaymentError(exception.getPaymentErrorList().get(0));
-		}
-	}
+    @Test
+    public void given_an_error_message_then_payment_exception_is_thrown() {
+        try {
+            JsonParser parser = new JsonParser();
+            parser.fromJson(TestData.errorJson(), JsonCharge.class);
 
-	@Test
-	public void given_an_error_json_then_fromJson_returnes_jsonerrorobject() {
-		assertJsonError(new JsonParser().fromJson(TestData.errorJson(), JsonErrorObject.class));
-	}
+            fail("Expected PaymentException");
+        } catch (PaymentException exception) {
+            assertBasicErrorAttributes(exception.getId(), exception.getUrl(), exception.getTimestamp());
+            assertPaymentError(exception.getPaymentErrorList().get(0));
+        }
+    }
 
-	private void assertJsonError(JsonErrorObject expectedError) {
-		assertBasicErrorAttributes(expectedError.getId(), expectedError.getUrl(), expectedError.getTimestamp());
-		assertEquals(1, expectedError.getErrors().size());
-		assertPaymentError(expectedError.getErrors().get(0));
-	}
+    @Test
+    public void given_an_error_json_then_fromJson_returnes_jsonerrorobject() {
+        assertJsonError(new JsonParser().fromJson(TestData.errorJson(), JsonErrorObject.class));
+    }
 
-	private void assertBasicErrorAttributes(String id, String url, String timestamp) {
-		assertEquals("s-err-f2ea241e5e8e4eb3b1513fab12c", id);
-		assertEquals("https://api.unzer.com/v1/payments/charges", url);
-		assertEquals("2019-01-09 15:42:24", timestamp);
+    @Test
+    public void testValidJson() {
+        assertTrue(new JsonParser().isJsonValid("{\"name\": \"value\"}"));
+    }
 
-	}
+    @Test
+    public void testInvalidJson() {
+        assertFalse(new JsonParser().isJsonValid("This is an error message!"));
+    }
 
-	private void assertPaymentError(PaymentError error) {
-		assertEquals("COR.400.100.101", error.getCode());
-		assertEquals("Address untraceable", error.getMerchantMessage());
-		assertEquals("The provided address is invalid. Please check your input and try agian.",
-				error.getCustomerMessage());
-	}
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromInvalidJson() {
+        new JsonParser().fromJson("This is an error message!", Payment.class);
+    }
+
+    private void assertJsonError(JsonErrorObject expectedError) {
+        assertBasicErrorAttributes(expectedError.getId(), expectedError.getUrl(), expectedError.getTimestamp());
+        assertEquals(1, expectedError.getErrors().size());
+        assertPaymentError(expectedError.getErrors().get(0));
+    }
+
+    private void assertBasicErrorAttributes(String id, String url, String timestamp) {
+        assertEquals("s-err-f2ea241e5e8e4eb3b1513fab12c", id);
+        assertEquals("https://api.unzer.com/v1/payments/charges", url);
+        assertEquals("2019-01-09 15:42:24", timestamp);
+
+    }
+
+    private void assertPaymentError(PaymentError error) {
+        assertEquals("COR.400.100.101", error.getCode());
+        assertEquals("Address untraceable", error.getMerchantMessage());
+        assertEquals("The provided address is invalid. Please check your input and try agian.",
+                error.getCustomerMessage());
+    }
 }

--- a/src/test/java/com/unzer/payment/communication/JsonParserTest.java
+++ b/src/test/java/com/unzer/payment/communication/JsonParserTest.java
@@ -27,6 +27,8 @@ import com.unzer.payment.communication.json.JsonCharge;
 import com.unzer.payment.communication.json.JsonErrorObject;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.*;
 
 public class JsonParserTest extends AbstractPaymentTest {
@@ -57,6 +59,21 @@ public class JsonParserTest extends AbstractPaymentTest {
     @Test
     public void testInvalidJson() {
         assertFalse(new JsonParser().isJsonValid("This is an error message!"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullJson() {
+        new JsonParser().fromJson(null, Payment.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullClass() {
+        new JsonParser().fromJson("{\"name\": \"value\"}", null);
+    }
+
+    @Test
+    public void testNullValidJson() {
+        assertFalse(new JsonParser().isJsonValid(null));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/unzer/payment/communication/JsonParserTest.java
+++ b/src/test/java/com/unzer/payment/communication/JsonParserTest.java
@@ -27,8 +27,6 @@ import com.unzer.payment.communication.json.JsonCharge;
 import com.unzer.payment.communication.json.JsonErrorObject;
 import org.junit.Test;
 
-import java.io.IOException;
-
 import static org.junit.Assert.*;
 
 public class JsonParserTest extends AbstractPaymentTest {


### PR DESCRIPTION
…ppens and added tests for it. Positive Tests for `fromJson` are not possible because of recursive references inside most of the Payment-relevant Classes (e.g. Unzer reference).